### PR TITLE
test for meta

### DIFF
--- a/shared_session/templatetags/shared_session.py
+++ b/shared_session/templatetags/shared_session.py
@@ -66,6 +66,10 @@ class LoaderNode(template.Node):
         if request.session.is_empty():
             return ''
 
+        # Sometimes host is not in meta, ex. in tests.
+        if 'HTTP_HOST' not in request.META:
+            return ''
+
         try:
             self.ensure_session_key(request)
 


### PR DESCRIPTION
Tests fail when `HTTP_HOST` is not in meta, this (hopefully) protects from those failures.